### PR TITLE
chore: Configure Dependabot for fairy-stockfish-nnue.wasm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+    # Group updates for better PR management
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+
+    # Open pull requests for security and version updates
+    open-pull-requests-limit: 5
+
+    # Dependabot will automatically ignore prerelease versions when the current
+    # version is stable (e.g., 1.1.9). Only proper semantic versions (x.y.z)
+    # will be suggested for updates, not prereleases (x.y.z-alpha.1, etc.)
+
+    # Labels for the pull requests
+    labels:
+      - "dependencies"
+      - "automated"
+
+    # Commit message preferences
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,23 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+    # Open pull requests for GitHub Actions updates
+    open-pull-requests-limit: 5
+
+    # Labels for the pull requests
+    labels:
+      - "dependencies"
+      - "github-actions"
+      - "automated"
+
+    # Commit message preferences
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
- Add Dependabot configuration to automatically track npm dependencies
- Configure daily checks for fairy-stockfish-nnue.wasm updates
- Dependabot will only suggest stable releases (x.y.z), not prereleases
- Group dependency updates and limit to 5 open PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)